### PR TITLE
Fix pyproject authors spacing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ultracivic-backend"
 version = "0.1.0"
 description = "Ultra Civic backend API"
 authors = [
-    {name = "Francisco del Villar",email = "delvillarfr@gmail.com"}
+    {name = "Francisco del Villar", email = "delvillarfr@gmail.com"}
 ]
 license = {text = "MIT"}
 readme = "README.md"


### PR DESCRIPTION
## Summary
- fix author email spacing in `pyproject.toml`

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_684064785864832f81bc9d0da7ac5996