### PR TITLE
Fix async session generator

### DIFF
--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,5 +1,6 @@
 # app/db/__init__.py
-from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
 from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.ext.asyncio import create_async_engine
 from app.core.config import get_settings
@@ -10,8 +11,7 @@ engine = create_async_engine(
     settings.database_url, echo=False, pool_pre_ping=True
 )
 
-@asynccontextmanager
-async def get_session():
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
     async with AsyncSession(engine) as session:
         yield session
 

--- a/app/kyc/__init__.py
+++ b/app/kyc/__init__.py
@@ -42,7 +42,7 @@ async def stripe_webhook(request: Request):
         session = event["data"]["object"]
         user_id = UUID(session["client_reference_id"])
 
-        async with get_session() as db:
+        async for db in get_session():
             user = await db.get(User, user_id)
             if user:
                 user.kyc_status = "verified"


### PR DESCRIPTION
## Summary
- update db session helper to return an async generator
- adjust KYC webhook to use new generator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684074bbafd4832f8b1fdcaeeb13aefc