### PR TITLE
Expose verification token for dev use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,31 @@
 # Ultra Civic Backend
 
-This project uses SQLAlchemy with an async driver. Ensure your `DATABASE_URL`
-includes an async driver such as `postgresql+asyncpg`.
+This project uses SQLAlchemy with an async driver. Ensure your `DATABASE_URL` includes an async driver such as `postgresql+asyncpg`.
+
+## Running the KYC flow locally
+
+1. **Start the API**
+   ```bash
+   poetry run uvicorn app.main:app --reload
+   ```
+2. **Forward Stripe webhooks** (requires the Stripe CLI)
+   ```bash
+   stripe listen \
+     --events identity.verification_session.verified \
+     --forward-to localhost:8000/stripe/webhook
+   ```
+3. **Register and log in**
+   ```bash
+   http POST :8000/auth/register email=alice@test.com password=secret
+   TOKEN=$(http -f POST :8000/auth/jwt/login \
+              username=alice@test.com password=secret | jq -r .access_token)
+   ```
+4. **Kick off KYC**
+   ```bash
+   http POST :8000/kyc/start "Authorization: Bearer $TOKEN"
+   ```
+   Open the returned URL in your browser and click **Skip verification** in test mode.
+5. **Confirm verification**
+   - The Stripe CLI prints the webhook event.
+   - The FastAPI server logs `user <id> marked verified`.
+   - Query the database to see `kyc_status` set to `verified`.

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -52,6 +52,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, UUID]):
         # In production send email; for dev just print
         print(f"[DEV] reset-token for {user.email}: {token}")
 
+    async def on_after_request_verify(
+        self, user: User, token: str, request: Request | None = None
+    ) -> None:
+        """Print verification tokens for local testing."""
+        print(f"[DEV] Verification token for {user.email}: {token}")
+
 async def get_user_manager(
     user_db=Depends(get_user_db),
 ) -> AsyncGenerator[UserManager, None]:

--- a/app/kyc/__init__.py
+++ b/app/kyc/__init__.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 from uuid import UUID
+import logging
 import stripe
 
 from app.core.config import get_settings
@@ -8,6 +9,7 @@ from app.models.user import User
 from app.db import get_session
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 settings = get_settings()
 stripe.api_key = settings.stripe_secret     # 🔑
 
@@ -48,6 +50,7 @@ async def stripe_webhook(request: Request):
                 user.kyc_status = "verified"
                 db.add(user)
                 await db.commit()
+                logger.info("user %s marked verified", user.id)
 
     return {"received": True}
 

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,13 @@ app.include_router(
     tags=["auth"],
 )
 
+# Verification routes (prints token in console)
+app.include_router(
+    fastapi_users.get_verify_router(UserRead),
+    prefix="/auth",
+    tags=["auth"],
+)
+
 # 2) JWT login/logout → needs backend + response schema
 app.include_router(
     fastapi_users.get_auth_router(auth_backend, UserRead),

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- print email verification tokens to the console for easy local testing
- mount FastAPI-Users verify router so `/auth/request-verify-token` works

## Testing
- `ruff check .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_684073c37884832f980ba1dca3cb1866