### PR TITLE
Fix reserved attribute causing deployment crash

### DIFF
--- a/app/auth/session.py
+++ b/app/auth/session.py
@@ -16,7 +16,7 @@ Features:
 import secrets
 import string
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Literal, Optional
 from uuid import UUID
 
 from fastapi import Request, Response, HTTPException
@@ -129,7 +129,10 @@ class SessionService:
         secure: bool = True
     ) -> None:
         """Set session cookie in the response."""
-        samesite_setting = "none" if secure else "lax"
+        # Explicit literal typing for mypy compatibility
+        samesite_setting: Literal["lax", "strict", "none"] = (
+            "none" if secure else "lax"
+        )
         
         response.set_cookie(
             key=SessionService.SESSION_COOKIE_NAME,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -14,7 +14,11 @@ import sys
 from enum import Enum
 from functools import lru_cache
 
-from pydantic import Field, SecretStr, field_validator
+try:
+    # Pydantic v2
+    from pydantic import Field, SecretStr, field_validator  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover - fallback for older Pydantic versions
+    from pydantic import Field, SecretStr, validator as field_validator  # type: ignore
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -113,7 +113,12 @@ class PaymentIntent(Base):
     
     # Metadata
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    metadata: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON string
+    metadata_json: Mapped[Optional[str]] = mapped_column(
+        "metadata",
+        Text,
+        nullable=True,
+        comment="JSON string stored as text",
+    )
     
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))

--- a/app/payments/__init__.py
+++ b/app/payments/__init__.py
@@ -157,7 +157,7 @@ class PaymentService:
                 status=PaymentStatus(stripe_intent.status),
                 capture_method="manual",
                 description=stripe_intent.description,
-                metadata=json.dumps(stripe_intent.metadata)
+                metadata_json=json.dumps(stripe_intent.metadata)
             )
             
             db.add(payment_intent)


### PR DESCRIPTION
## Summary
- rename PaymentIntent.metadata attribute to avoid conflict with SQLAlchemy declarative `metadata`
- alias `field_validator` for older Pydantic versions
- annotate session cookie samesite setting for typing

## Testing
- `poetry run ruff check .`
- `poetry run mypy .`


------
https://chatgpt.com/codex/tasks/task_e_6849f5a425dc832fbd3bb84bb9420a3a