### PR TITLE
Fix pydantic regex parameter

### DIFF
--- a/app/payments/__init__.py
+++ b/app/payments/__init__.py
@@ -42,7 +42,11 @@ stripe.api_key = settings.stripe_secret.get_secret_value()
 class OrderRequest(BaseModel):
     """Request schema for creating a new order."""
     tonnes_co2: int = Field(gt=0, le=1000, description="Number of CO2 tonnes to retire")
-    eth_address: Optional[str] = Field(None, regex=r"^0x[a-fA-F0-9]{40}$", description="Ethereum address for token delivery")
+    eth_address: Optional[str] = Field(
+        default=None,
+        pattern=r"^0x[a-fA-F0-9]{40}$",
+        description="Ethereum address for token delivery",
+    )
 
 
 class OrderResponse(BaseModel):


### PR DESCRIPTION
## Summary
- update payment order request to use `pattern` parameter for Pydantic v2

## Testing
- `ruff check .`
- `mypy app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f92b48a4832fb12f99062c7bc11b